### PR TITLE
create slsfiles in ansible (skip Setup Script Step), prechecks for user provided inputs

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -16,24 +16,6 @@
     - name: Print OS Version
       debug:
         msg: "OS Version is {{ ansible_distribution }} {{ ansible_distribution_version }}"    
-    # - name: Get BIOS Revision
-    #   become: true
-    #   command: dmidecode -t bios
-    #   register: bios_revision
-    # - name: Extract BIOS Revision
-    #   set_fact:
-    #     bios_revision_line: "{{ bios_revision.stdout_lines | select('search', 'BIOS Revision') | regex_search('([0-9.]+)') }}"
-    #     bios_vendor_line: "{{ bios_revision.stdout_lines | select('search', 'Vendor') | map('trim') | join('') }}"
-    # - name: Fail if outdated BIOS
-    #   fail:
-    #     msg: "Please manually upgrade your machine's BIOS\nLeaseweb: 2.15.3 or newer from https://www.dell.com/support/home/en-us/product-support/product/poweredge-r6515/drivers\nOVH: 5.22 or newer"
-    #   when: "('American Megatrends International' in bios_vendor_line and bios_revision_line is version('5.22', '<')) or ('Dell Inc' in bios_vendor_line and bios_revision_line is version('2.15', '<'))"
-    - name: Ensure secrets.sls exists (must create manually, follow https://www.notion.so/litprotocol/Datil-test-Testnet-Node-Provisioning-Guide-6c78bd5e7ebd4b0f8cec1ad78e130be2?pvs=4#28c6372c37274b609e8866797da8abc5)
-      stat:
-        path: /root/.salt-local/secrets.sls
-      register: secrets_file
-      failed_when: "not secrets_file.stat.exists"
-
     - name: Print network info before upgrade
       block:
         - name: Read the /etc/network/interfaces file
@@ -52,6 +34,8 @@
         - name: Print ip a output
           debug:
             var: ip_a_output.stdout
+    - name: run pre-deploy checks
+      include_tasks: tasks/prechecks.yml
 
   tasks:
     - name: set internal variables
@@ -59,6 +43,9 @@
 
     - name: Stop running nodes
       include_tasks: tasks/stop_all_instances.yml
+
+    - name: Write salt files
+      include_tasks: tasks/write_salt_files.yml
 
     - name: Upgrade Debian packages
       include_tasks: tasks/upgrade_debian.yml

--- a/files/defaults.sls
+++ b/files/defaults.sls
@@ -1,0 +1,1 @@
+timezone: America/New_York

--- a/files/git.sls.j2
+++ b/files/git.sls.j2
@@ -1,0 +1,11 @@
+git_repo:
+  lit-os:
+    url: git@github.com:LIT-Protocol/lit-os.git
+    branch:
+      default: main
+      {{ env }}: {{ hostvars[inventory_hostname]['branch-os'] }}
+  lit-assets:
+    url: git@github.com:LIT-Protocol/lit-assets.git
+    branch:
+      default: main
+      {{ env }}: {{ hostvars[inventory_hostname]['branch-assets'] }}

--- a/files/security.sls
+++ b/files/security.sls
@@ -1,0 +1,9 @@
+firewall:
+  allowed_ports:
+    22:
+      protocol: tcp
+      source:
+        - 0.0.0.0/0
+
+sshd_allow_passwords: False
+sshd_bind_localhost: False

--- a/files/users.sls.j2
+++ b/files/users.sls.j2
@@ -1,0 +1,164 @@
+users:
+  {{ ssh_user }}:
+    active: True
+    name: Not Set
+    email: {{ root_email }}
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - {{ ssh_public_key }}
+{% if network_name == "datil_test" %}
+  mike:
+    active: True
+    name: Mike L
+    email: mike@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyCKHIxBG7XlMpDqyI7GKvNv7UCkdd4mCnEGV98xObH
+  chris:
+    active: True
+    name: Chris C
+    email: chris@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJBadixwLYNJje+dMIbei9mnAfagGV7EGH1G0sJNaXLP4t3qiJnZpApubSoV/6oEcf3O8MNbPh153VnnrUpYgfA= Lit-Protocol@secretive.h4ckb00k-m1.local
+      - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBIpMMJlUMi+5301UJyFw2yJX9Cs53RgGKvnODCW/qJGSw9IcoIHxlfdmmE/Dhy82jTKh44K8Ur2FCaXmnwknj59zqrZ7l2jrOC3IuduQ0KrYTp3Sbkyk3acESIBJ7/PURw== Key-For-PIV-Authentication-(chris)@secretive.h4ckb00k-m1.local
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP5uQh+KHcXs9LYyhkzBDcZv4HYgjRDzK8eDf+VOQVHi chris@litprotocol.com
+  howard:
+    active: True
+    name: Howard
+    email: howard@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE5Ue8ib58nHNCbWaaZzFSstZVdSu5p6p27ISjz6yhNi howard.tam.95@gmail.com
+      - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFx4XvIefOJOJAVPNeAzT8NolNTt7KLMOP05UboxtGHNwxgkHiQQqulXUz90l6jCwl5/oSCINWiE4yjPmkB+WRU= Git@secretive.Howard’s-MacBook-Pro.local
+  brendon:
+    active: True
+    name: Brendon
+    email: brendon@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCodvWfWQDrahjyOqlFGbZELjtpZwbg6ZA46ihX8ZtNgSdiZ5De9ikrbyTaFnjByGFr9U4yDVVB3VsPeDsl/p/mD6nLtl/9qIXg4tFiuJNrtoVnyVyHnxzV5Jcip70w2CE5tXznkAr0Gmy6qfrqCWCE1X+3imitL1x68+n4jNmtvHhNXGSB1vDpYZmpq3HpL3N/VeJMJX/jJqMLlPm9YBMJh4UFBbeYoMm27qfFhcGjbipBscQoNQgOlLRvgZzFYMLEy4jWjgmWQi+eajxcZfWjlZnfYJO6Z+A5FiekJ6hXBLBrn86Ng1VVfm3+PhuohkJ8qXGwhXzymA9gzDDdJUdS0ZtN6bL54KshKB56G3nehB0TogcQpQPxqFoJxPW7yYq6enhHxpio/F3xCtxiB8Jl3QkJaHPPwmQR9PAgn6gSPZ8QtELmReHjElLUj+3DAhJUflR6yPHqKmTU4eXKMbwWVt/5AZlMtbuU6Mq2V4eeZO0TuIwhG5JyDgAcGXTEBefpt32oT3yAMIsL6sAx0bUyhAlKQRZNV5LND1rjkpSwIEG3LDsSFgtw5aMGWiTIK8kdyFhKTWiK1/Rieau0sbjcCyGEn7aZPK8/1yK8MV204YAjjA/FSp+55pyjzSECUMJ+k+Ku2rM3deJ/PjNuA/F3ZyiB+qlADceWwuisuv9Dzw== brendonpaul@Brendons-MacBook-Pro.local
+  josh:
+    active: True
+    name: Josh Long
+    email: josh@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC6xrKK3zK760xHSRxC4WJYQVblgoe9G34CatdMnvvhOUUm4QSPCp1YR6sU8Xahz3h6v0xYzER7Vw+lj65DwSl7zQ3jFKGhUJRF7EPhoDxts35LyAWpT28/zJCiWLTo7M7Dc4vptKY/DrvvxF5poEy6xWZtTf9zv2w9fMJMXsJm77me/+YWS5i2dM9M1ZEAO47tWybHoA0bMxWmiMmfZMWECeWTUFaAFT4kfPfoh84z7T9MHDUig19YS2XpngfxwzAbq43Xfrx2ESyZ6kau+GViBIRzwdhh7lub/Rf6QUmVmmbmc9anq4PxNOKqBV/8M4VHrf00XEcEgkufqQjgO8uZ0865D4TCrzQTjI0nOWXIyggjr8JkJXkdbBLw7m2YPrHQCmLo6cW9UPTrI97Pj8azhgljKu72Iabn/80OsfFnFndSR5kK9go6vMKjrJ3zxmy4OWaZUIEJfWDZ6ynBtHlYut7IkFsSEg3WZ4CmmA6gCs8SeHjLrXCpDODMW0QNVXc= joshlong@joshs-MacBook-Pro.local
+  rahul:
+    active: True
+    name: Rahul
+    email: rahul@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC5mOVi1Jq+enynrmJW14PqNptPi6KJlFFom8YtGKJ/TyXyWSO9/Q84A5NyvMj8kS4bTeCZpGl2f4LK1Z2eqHhIxYW+FvnHseO/Dx6KAABxIPf5dp77AhQymCq3byvbtVWI8c60dkPTVO1kL5113zFvNfjwuPsOSHF3sx4H3GqL9UxHMmvINzbl/0Z/wRsX0bQRcS7973Og9RIoX+fpHgveH8t0C7bI2RMoyr1qTxfdtYIhIc27cLyuPAVVBNtzUsg9v9l9JgCQarkFPjA1Kmve3M3tQDHbk+mU0qcVaPZMPaonn3hpYGjZOi+FLVNVAWAQ9S3G5qyTqeTV0SbE2UlrbMrm62H5WExUasxjeszdQ9V3OnBbP47yMyr5hpwCVc5Jln6HPeX2+MRIb+iX1W8bdBtzSmW5hLX0bs7EDV0nU8VRVh3MjKX9/zxsPhTz0jevXW/WmOLYtRpCUj/LJ2AXf+CuFPt84IOowv0IKlSHiB5JMEovRQfJxfbZm/AmQmE= rahulramesh@Sentinel
+  egeyar:
+    active: True
+    name: Egeyar
+    email: egeyar@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDsZimkfXXuhoVdTJec+ZZX8Tu6xdHuMdzcxmxY9b7np egeyar@litprotocol.com
+  nicholas:
+    active: True
+    name: Nicholas Young
+    email: nicholas@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB39zNOokcjcuwqM6uxwu4PQBir224LbHnYHEGxq8TjV nicholas@litprotocol.com
+  adam:
+    active: True
+    name: Adam Reif
+    email: adam@litprotocol.com
+    shell: /bin/bash
+    groups:
+      - lit
+      - admin
+    access:
+      - prod
+      - staging
+      - dev
+    features:
+      - rust
+    ssh_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApBWGz5gdYttQgru11P2LM+kKtbJ9uzjaL8h45Q2kHG adam@litprotocol.com
+{% endif %}

--- a/machine-description.yml
+++ b/machine-description.yml
@@ -1,14 +1,19 @@
 all: # Customize / set the lines with numbered comments
   vars:
-    ansible_user:  # 1. Set the linux username you use for logging into the host below
+    # NOTE: Anything until the hosts section is your personal information, no need to share it with the lit team
+    ansible_user:  # 1. Set the linux username you use for logging into the host below (this is idential to `ssh_user`, unless you're doing a fresh install, then it's the initial user, likely `root` or `debian` )
     ansible_ssh_private_key_file:  # 2. Set the path to the ssh key you use to log in to your box, e.g. "~/.ssh/id_ed25519" (with quotes)
     network_name:  # 3. datil_test or datil
     root_email:  # 4. Add your admin E-Mail Address, e.g. foo@bar.com
+    ssh_user:  # 5. Set the username you want to use for SSH connections to your box after lit-os installation is complete (please don't use root, you can always `sudo`)
+    # 6. Set the public key (in quotes) that matches the ansible_ssh_private_key_file above, the user you set in 5. will be able to log in with that key after install completes
+    # e.g. ssh_public_key: "ssh-ed25519 AAAAC3NzaC1lZgI1NTE5AAAAI2pBWGz5gdYttQgru11f27M+kKtbJ9uzjaL8d45Q23Hp me@nowhere.com" 
+    ssh_public_key: 
     branch-os: develop
     branch-assets: datil
   hosts:
     my-box:
-      # ========= 5. Fill out your machine info below ================== #
+      # ========= 7. Fill out your machine info below and share it with the lit team ================== #
       # provider: ovh or leaseweb
       provider: 
       # provider_class: advance or scale for OVH, leave empty for leaseweb or others

--- a/tasks/install_litos.yml
+++ b/tasks/install_litos.yml
@@ -43,23 +43,6 @@
     path: /root/.salt-local
     state: directory
 
-- name: Set branches in git.sls (create new file)
-  copy:
-    content: |
-        git_repo:
-          lit-os:
-            url: git@github.com:LIT-Protocol/lit-os.git
-            branch:
-              default: main
-              {{ env }}: {{ hostvars[inventory_hostname]['branch-os'] }}
-          lit-assets:
-            url: git@github.com:LIT-Protocol/lit-assets.git
-            branch:
-              default: main
-              {{ env }}: {{ hostvars[inventory_hostname]['branch-assets'] }}
-    dest: /root/.salt-local/git.sls
-    force: true
-
 - name: Display the updated /root/.salt-local/git.sls
   command: grep dev /root/.salt-local/git.sls
   register: git_sls_content
@@ -78,7 +61,7 @@
     - /root/lit-os-prov
     - /root/lit-os-prov.tgz
 
-- name: Ensure secrets.sls exists (create manually if it doesnt)
+- name: Ensure secrets.sls exists
   stat:
     path: /root/.salt-local/secrets.sls
   register: secrets_file

--- a/tasks/prechecks.yml
+++ b/tasks/prechecks.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if vars have been provided
+  ansible.builtin.assert:
+    that:
+      - network_name is defined and network_name in ["datil_test", "datil"]
+      - root_email is defined and root_email | length > 0
+      - ssh_user is defined and ssh_user | length > 0
+      - ssh_public_key is defined and ssh_public_key | length > 0
+      - provider is defined and provider | length > 0
+      - (provider == 'ovh' and provider_class in ["advance", "scale"]) or provider_class == ""
+      - ansible_host is defined and ansible_host | length > 0
+      - host_ip is defined and host_ip | length > 0
+      - host_gw is defined and host_gw | length > 0
+      - guest_ip is defined and guest_ip | length > 0
+      - guest_gw is defined and guest_gw | length > 0
+    fail_msg: "Error: Some required information was not provided, please revisit machine-description.yml"
+
+# - name: Get BIOS Revision
+#   become: true
+#   command: dmidecode -t bios
+#   register: bios_revision
+# - name: Extract BIOS Revision
+#   set_fact:
+#     bios_revision_line: "{{ bios_revision.stdout_lines | select('search', 'BIOS Revision') | regex_search('([0-9.]+)') }}"
+#     bios_vendor_line: "{{ bios_revision.stdout_lines | select('search', 'Vendor') | map('trim') | join('') }}"
+# - name: Fail if outdated BIOS
+#   fail:
+#     msg: "Please manually upgrade your machine's BIOS\nLeaseweb: 2.15.3 or newer from https://www.dell.com/support/home/en-us/product-support/product/poweredge-r6515/drivers\nOVH: 5.22 or newer"
+#   when: "('American Megatrends International' in bios_vendor_line and bios_revision_line is version('5.22', '<')) or ('Dell Inc' in bios_vendor_line and bios_revision_line is version('2.15', '<'))"

--- a/tasks/write_salt_files.yml
+++ b/tasks/write_salt_files.yml
@@ -1,0 +1,53 @@
+- name: Create the directory for the sls files
+  ansible.builtin.file:
+    path: "/root/.salt-local"
+    state: directory
+
+- name: Copy defaults.sls file
+  ansible.builtin.copy:
+    src: files/defaults.sls
+    dest: "/root/.salt-local/defaults.sls"
+    mode: '0644'
+    force: true
+
+- name: Copy security.sls file
+  ansible.builtin.copy:
+    src: files/security.sls
+    dest: "/root/.salt-local/security.sls"
+    mode: '0644'
+    force: true
+
+- name: Deploy users.sls file
+  ansible.builtin.template:
+    src: files/users.sls.j2
+    dest: "/root/.salt-local/users.sls"
+    mode: '0644'
+    force: true
+
+- name: Deploy git.sls file
+  ansible.builtin.template:
+    src: files/git.sls.j2
+    dest: "/root/.salt-local/git.sls"
+    mode: '0644'
+    force: true
+
+- name: Deploy secrets.sls file
+  block:
+    - name: Download archive
+      get_url:
+        url: https://storage.googleapis.com/lit-protocol-official-packages/saltcreds.zip
+        dest: /root/.salt-local/saltcreds.zip
+        validate_certs: false
+        force: true
+    - name: unzip
+      unarchive:
+        remote_src: yes
+        src: /root/.salt-local/saltcreds.zip
+        dest: /root/.salt-local/
+        extra_opts:
+          - "-P"
+          - "thisisforDATIL"
+    - name: cleanup
+      ansible.builtin.file:
+        state: absent
+        path: /root/.salt-local/saltcreds.zip


### PR DESCRIPTION
i copied the secrets.sls file into `lit-os` root (since we're keeping it closed source for now) and created the zipfile with an addition to the `makefile` there, i'll create litos PR in a bit

the encrypted zipfile of secrets.sls lives on the google cloud bucket with a static password